### PR TITLE
cerebras[minor]: release 0.5

### DIFF
--- a/libs/cerebras/langchain_cerebras/chat_models.py
+++ b/libs/cerebras/langchain_cerebras/chat_models.py
@@ -34,7 +34,7 @@ class ChatCerebras(BaseChatOpenAI):
     Key init args — completion params:
         model: str
             Name of model to use.
-        temperature: float
+        temperature: Optional[float]
             Sampling temperature.
         max_tokens: Optional[int]
             Max number of tokens to generate.
@@ -42,7 +42,7 @@ class ChatCerebras(BaseChatOpenAI):
     Key init args — client params:
         timeout: Union[float, Tuple[float, float], Any, None]
             Timeout for requests.
-        max_retries: int
+        max_retries: Optional[int]
             Max number of retries.
         api_key: Optional[str]
             Cerebras API key. If not passed in will be read from env var CEREBRAS_API_KEY.
@@ -318,9 +318,9 @@ class ChatCerebras(BaseChatOpenAI):
     @model_validator(mode="after")
     def validate_environment(self) -> Self:
         """Validate that api key and python package exists in environment."""
-        if self.n < 1:
+        if self.n is not None and self.n < 1:
             raise ValueError("n must be at least 1.")
-        if self.n > 1 and self.streaming:
+        if self.n is not None and self.n > 1 and self.streaming:
             raise ValueError("n must be 1 when streaming.")
 
         client_params = {
@@ -332,10 +332,11 @@ class ChatCerebras(BaseChatOpenAI):
             # Ensure we always fallback to the Cerebras API url.
             "base_url": self.cerebras_api_base,
             "timeout": self.request_timeout,
-            "max_retries": self.max_retries,
             "default_headers": self.default_headers,
             "default_query": self.default_query,
         }
+        if self.max_retries is not None:
+            client_params["max_retries"] = self.max_retries
 
         if self.cerebras_proxy and (self.http_client or self.http_async_client):
             raise ValueError(

--- a/libs/cerebras/poetry.lock
+++ b/libs/cerebras/poetry.lock
@@ -375,22 +375,22 @@ files = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.19"
+version = "0.3.29"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "langchain_core-0.3.19-py3-none-any.whl", hash = "sha256:562b7cc3c15dfaa9270cb1496990c1f3b3e0b660c4d6a3236d7f693346f2a96c"},
-    {file = "langchain_core-0.3.19.tar.gz", hash = "sha256:126d9e8cadb2a5b8d1793a228c0783a3b608e36064d5a2ef1a4d38d07a344523"},
+    {file = "langchain_core-0.3.29-py3-none-any.whl", hash = "sha256:817db1474871611a81105594a3e4d11704949661008e455a10e38ca9ff601a1a"},
+    {file = "langchain_core-0.3.29.tar.gz", hash = "sha256:773d6aeeb612e7ce3d996c0be403433d8c6a91e77bbb7a7461c13e15cfbe5b06"},
 ]
 
 [package.dependencies]
 jsonpatch = ">=1.33,<2.0"
-langsmith = ">=0.1.125,<0.2.0"
+langsmith = ">=0.1.125,<0.3"
 packaging = ">=23.2,<25"
 pydantic = [
-    {version = ">=2.7.4,<3.0.0", markers = "python_full_version >= \"3.12.4\""},
     {version = ">=2.5.2,<3.0.0", markers = "python_full_version < \"3.12.4\""},
+    {version = ">=2.7.4,<3.0.0", markers = "python_full_version >= \"3.12.4\""},
 ]
 PyYAML = ">=5.3"
 tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<10.0.0"
@@ -398,24 +398,19 @@ typing-extensions = ">=4.7"
 
 [[package]]
 name = "langchain-openai"
-version = "0.2.0"
+version = "0.3.0"
 description = "An integration package connecting OpenAI and LangChain"
 optional = false
-python-versions = ">=3.9,<4.0"
-files = []
-develop = false
+python-versions = "<4.0,>=3.9"
+files = [
+    {file = "langchain_openai-0.3.0-py3-none-any.whl", hash = "sha256:49c921a22d272b04749a61e78bffa83aecdb8840b24b69f2909e115a357a9a5b"},
+    {file = "langchain_openai-0.3.0.tar.gz", hash = "sha256:88d623eeb2aaa1fff65c2b419a4a1cfd37d3a1d504e598b87cf0bc822a3b70d0"},
+]
 
 [package.dependencies]
-langchain-core = "^0.3"
-openai = "^1.40.0"
+langchain-core = ">=0.3.29,<0.4.0"
+openai = ">=1.58.1,<2.0.0"
 tiktoken = ">=0.7,<1"
-
-[package.source]
-type = "git"
-url = "https://github.com/langchain-ai/langchain.git"
-reference = "HEAD"
-resolved_reference = "bd42344b0ac5cdd3557d00661dbf44fbc62faf7d"
-subdirectory = "libs/partners/openai"
 
 [[package]]
 name = "langchain-tests"
@@ -449,8 +444,8 @@ files = [
 httpx = ">=0.23.0,<1"
 orjson = ">=3.9.14,<4.0.0"
 pydantic = [
-    {version = ">=2.7.4,<3.0.0", markers = "python_full_version >= \"3.12.4\""},
     {version = ">=1,<3", markers = "python_full_version < \"3.12.4\""},
+    {version = ">=2.7.4,<3.0.0", markers = "python_full_version >= \"3.12.4\""},
 ]
 requests = ">=2,<3"
 requests-toolbelt = ">=1.0.0,<2.0.0"
@@ -515,13 +510,13 @@ files = [
 
 [[package]]
 name = "openai"
-version = "1.45.0"
+version = "1.59.6"
 description = "The official Python library for the openai API"
 optional = false
-python-versions = ">=3.7.1"
+python-versions = ">=3.8"
 files = [
-    {file = "openai-1.45.0-py3-none-any.whl", hash = "sha256:2f1f7b7cf90f038a9f1c24f0d26c0f1790c102ec5acd07ffd70a9b7feac1ff4e"},
-    {file = "openai-1.45.0.tar.gz", hash = "sha256:731207d10637335413aa3c0955f8f8df30d7636a4a0f9c381f2209d32cf8de97"},
+    {file = "openai-1.59.6-py3-none-any.whl", hash = "sha256:b28ed44eee3d5ebe1a3ea045ee1b4b50fea36ecd50741aaa5ce5a5559c900cb6"},
+    {file = "openai-1.59.6.tar.gz", hash = "sha256:c7670727c2f1e4473f62fea6fa51475c8bc098c9ffb47bfb9eef5be23c747934"},
 ]
 
 [package.dependencies]
@@ -536,6 +531,7 @@ typing-extensions = ">=4.11,<5"
 
 [package.extras]
 datalib = ["numpy (>=1)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
+realtime = ["websockets (>=13,<15)"]
 
 [[package]]
 name = "orjson"
@@ -644,8 +640,8 @@ files = [
 annotated-types = ">=0.6.0"
 pydantic-core = "2.23.3"
 typing-extensions = [
-    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
     {version = ">=4.6.1", markers = "python_version < \"3.13\""},
+    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
 ]
 
 [package.extras]
@@ -1187,4 +1183,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "d4fdbd554960f42a2a2e1d4846a767101b38c59407415f1f462a130e37585ff1"
+content-hash = "9074fe86e6c697ce05944992fd8689e0accb2459bb0523518b7f2d42d4e94306"

--- a/libs/cerebras/pyproject.toml
+++ b/libs/cerebras/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-cerebras"
-version = "0.4.0"
+version = "0.5.0"
 description = "An integration package connecting Cerebras and LangChain"
 authors = []
 readme = "README.md"
@@ -13,8 +13,8 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-langchain-core = "^0.3.0"
-langchain-openai = "^0.2.0"
+langchain-core = "^0.3.29"
+langchain-openai = "^0.3.0"
 
 [tool.poetry.group.test]
 optional = true


### PR DESCRIPTION
Update `langchain-openai` to 0.3. See [release notes](https://github.com/langchain-ai/langchain/releases/tag/langchain-openai%3D%3D0.3.0) for details. Should only impact default values of `temperature`, `n`, and `max_retries`.